### PR TITLE
lerp() function with less traits requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ assert_eq!(vec![3.0, 3.5, 4.0, 4.5], items);
 assert_eq!(vec![3.0, 5.0], 3.0.lerp_iter_closed(5.0, 2).collect::<Vec<_>>());
 ```
 
-Of course, the real benefit is that it's derivation is broad enough that it also covers types such as `num::Complex<T>`. If you have an array-processing library, and the arrays are `T: Copy + Add<Output = T> + Sub<Output = T> + Mul<F: Float, Output = T>`, it'll just work for them as well.
+Of course, the real benefit is that it's derivation is broad enough that it also covers types such as `num::Complex<T>`. If you have an array-processing library, and the arrays are `T: Add<Output = T> + Mul<F: Float, Output = T>`, it'll just work for them as well.
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ extern crate num_traits;
 
 use std::iter;
 use std::iter::{Skip, Chain, Once};
-use std::ops::{Add, Sub, Mul};
+use std::ops::{Add, Mul};
 use num_traits::{Float, Zero, One};
 
 /// Types which are amenable to linear interpolation and extrapolation.
@@ -15,7 +15,7 @@ use num_traits::{Float, Zero, One};
 /// scalar while retaining their own type.
 ///
 /// It's automatically implemented
-/// for all `T: Copy + Add<Output = T> + Sub<Output = T> + Mul<F, Output = T>`.
+/// for all `T: Add<Output = T> + Mul<F, Output = T>`.
 pub trait Lerp<F> {
     /// Interpolate and extrapolate between `self` and `other` using `t` as the parameter.
     ///
@@ -153,11 +153,11 @@ pub trait LerpIter {
 /// numbers, vectors, and other types which may be multiplied by a
 /// scalar while retaining their own type.
 impl<T, F> Lerp<F> for T
-    where T: Copy + Add<Output = T> + Sub<Output = T> + Mul<F, Output = T>,
+    where T: Add<Output = T> + Mul<F, Output = T>,
           F: Float
 {
     fn lerp(self, other: T, t: F) -> T {
-        self + ((other - self) * t)
+        self * (F::one() - t) + other * t
     }
 }
 


### PR DESCRIPTION
Hi, I am currently learning rust, and had a look at your nice little project. I've modified the lerp method bit so that it has less traits requirements. It should still do exactly the same as before, at least all the tests still work.
