### PR TITLE
Mutating lerp functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,23 @@ pub trait Lerp<F> {
         };
         self.lerp(other, t)
     }
+
+    /// Mutating variant of [`Lerp::lerp`].
+    fn lerp_to(&mut self, other: Self, t: F)
+    where
+        Self: Sized + Copy,
+    {
+        *self = self.lerp(other, t);
+    }
+
+    /// Mutating variant of [`Lerp::lerp_bounded`].
+    fn lerp_bounded_to(&mut self, other: Self, t: F)
+    where
+        Self: Sized + Copy,
+        F: PartialOrd + Copy + Zero + One,
+    {
+        *self = self.lerp_bounded(other, t);
+    }
 }
 
 /// Types which can construct a lerping iterator from one point to another

--- a/tests/manual.rs
+++ b/tests/manual.rs
@@ -13,7 +13,7 @@ fn manual() {
     struct Data {
         a: f64,
         b: f64,
-    };
+    }
 
     impl<F: Float> Lerp<F> for Data {
         fn lerp(self, other: Self, t: F) -> Self {
@@ -56,7 +56,7 @@ fn manual_mix() {
     struct Data {
         a: f64,
         b: f32,
-    };
+    }
 
     impl<F: crate::Float> Lerp<F> for Data {
         fn lerp(self, other: Self, t: F) -> Self {
@@ -95,7 +95,7 @@ fn manual_nested() {
     struct Data {
         a: InternalData,
         b: f32,
-    };
+    }
 
     impl<F: crate::Float> Lerp<F> for Data {
         fn lerp(self, other: Self, t: F) -> Self {

--- a/tests/manual.rs
+++ b/tests/manual.rs
@@ -9,7 +9,7 @@ mod common;
 
 #[test]
 fn manual() {
-    #[derive(PartialEq, Debug)]
+    #[derive(PartialEq, Debug, Clone, Copy)]
     struct Data {
         a: f64,
         b: f64,
@@ -29,7 +29,23 @@ fn manual() {
         round(&Data { a: 0.5, b: 0.5 })
     );
     assert_eq!(
+        {
+            let mut result = Data { a: 0.0, b: 1.0 };
+            result.lerp_to(Data { a: 1.0, b: 0.0 }, 0.5);
+            round(&result)
+        },
+        round(&Data { a: 0.5, b: 0.5 })
+    );
+    assert_eq!(
         round(&Data { a: 0.0, b: 1.0 }.lerp(Data { a: 1.0, b: 0.0 }, 0.9)),
+        round(&Data { a: 0.9, b: 0.1 })
+    );
+    assert_eq!(
+        {
+            let mut result = Data { a: 0.0, b: 1.0 };
+            result.lerp_to(Data { a: 1.0, b: 0.0 }, 0.9);
+            round(&result)
+        },
         round(&Data { a: 0.9, b: 0.1 })
     );
 }


### PR DESCRIPTION
Add a mutating variants of lerp functions:
- `lerp` → `lerp_to`
- `lerp_bounded` → `lerp_bounded_to`

The motivation behind this is that quite often I have a term in the form of `a = a.lerp(b, t)`. When `a` is not a simple variable but a series of field accessors, I do not want to alias a reference to the lerped field just to avoid the repetition.

Unfortunatly, since `lerp` takes ownerships of both interpolants, I have to add the `Copy` bound to `F` for the mutating functions.