### PR TITLE
chore: fix clippy lints

### DIFF
--- a/lerp_derive/src/derive.rs
+++ b/lerp_derive/src/derive.rs
@@ -46,7 +46,7 @@ impl Parse for LerpAttributes {
 
 fn lerp_field(name: &dyn ToTokens, ty: &Type, attrs: &Vec<Attribute>) -> syn::Result<TokenStream> {
     let attr = attrs
-        .into_iter()
+        .iter()
         .filter(|attr| attr.path.is_ident("lerp"))
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
Clippy has improved in the years since it was last run on this repo, so it catches more than it used to. Happily, this repo was pretty clean; only a little bit needed changing.